### PR TITLE
Call original function in test that expects to recieve collect

### DIFF
--- a/spec/reverse_each_word_spec.rb
+++ b/spec/reverse_each_word_spec.rb
@@ -7,12 +7,12 @@ describe '#reverse_each_word' do
   end
 
   let(:sentence2) { "Hi again, just making sure it's reversed!" }
-  it 'reverses all the words in a string without reversing the order of the words' do
+  it 'reverses all the words in another string without reversing the order of the words' do
     expect(reverse_each_word(sentence2)).to eq("iH ,niaga tsuj gnikam erus s'ti !desrever")
   end
 
   it 'uses collect' do
-    expect_any_instance_of(Array).to receive(:collect)
+    expect_any_instance_of(Array).to receive(:collect).and_call_original
     reverse_each_word("Verifying that collect is being called.")
   end
 end


### PR DESCRIPTION
If original function isn't called, rspec over-rides the return value of `#reverse_each_word` and returns nil. 

@pletcher @gj 